### PR TITLE
[improve][client] Make table view support non-persistent topic

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TableViewTest.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TableView;
+import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
 import org.apache.pulsar.common.policies.data.TenantInfoImpl;
@@ -77,6 +78,11 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
     @Override
     protected void cleanup() throws Exception {
         super.internalCleanup();
+    }
+
+    @DataProvider(name = "topicDomain")
+    public static Object[] topicDomain() {
+       return new Object[]{ TopicDomain.persistent.value(), TopicDomain.non_persistent.value()};
     }
 
     private Set<String> publishMessages(String topic, int count, boolean enableBatch) throws Exception {
@@ -155,11 +161,12 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         }
     }
 
-    @Test(timeOut = 30 * 1000)
-    public void testTableViewUpdatePartitions() throws Exception {
-        String topic = "persistent://public/default/tableview-test-update-partitions";
+    @Test(timeOut = 30 * 1000, dataProvider = "topicDomain")
+    public void testTableViewUpdatePartitions(String topicDomain) throws Exception {
+        String topic = topicDomain + "://public/default/tableview-test-update-partitions";
         admin.topics().createPartitionedTopic(topic, 3);
         int count = 20;
+        // For non-persistent topic, this keys will never be received.
         Set<String> keys = this.publishMessages(topic, count, false);
         @Cleanup
         TableView<byte[]> tv = pulsarClient.newTableViewBuilder(Schema.BYTES)
@@ -167,6 +174,9 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
                 .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
                 .create();
         log.info("start tv size: {}", tv.size());
+        if (topicDomain.equals(TopicDomain.non_persistent.value())) {
+            keys = this.publishMessages(topic, count, false);
+        }
         tv.forEachAndListen((k, v) -> log.info("{} -> {}", k, new String(v)));
         Awaitility.await().untilAsserted(() -> {
             log.info("Current tv size: {}", tv.size());
@@ -178,6 +188,10 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         admin.topics().updatePartitionedTopic(topic, 4);
         TopicName topicName = TopicName.get(topic);
 
+        // Make sure the new partition-3 consumer already started.
+        if (topic.startsWith(TopicDomain.non_persistent.toString())) {
+            TimeUnit.SECONDS.sleep(6);
+        }
         // Send more data to partition 3, which is not in the current TableView, need update partitions
         Set<String> keys2 =
                 this.publishMessages(topicName.getPartition(3).toString(), count * 2, false);
@@ -188,9 +202,9 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
         assertEquals(tv.keySet(), keys2);
     }
 
-    @Test(timeOut = 30 * 1000)
-    public void testPublishNullValue() throws Exception {
-        String topic = "persistent://public/default/tableview-test-publish-null-value";
+    @Test(timeOut = 30 * 1000, dataProvider = "topicDomain")
+    public void testPublishNullValue(String topicDomain) throws Exception {
+        String topic = topicDomain + "://public/default/tableview-test-publish-null-value";
         admin.topics().createPartitionedTopic(topic, 3);
 
         final TableView<String> tv = pulsarClient.newTableViewBuilder(Schema.STRING)
@@ -221,8 +235,12 @@ public class TableViewTest extends MockedPulsarServiceBaseTest {
                 .autoUpdatePartitionsInterval(5, TimeUnit.SECONDS)
                 .create();
 
-        assertEquals(tv1.size(), 1);
-        assertEquals(tv.get("key2"), "value2");
+        if (topicDomain.equals(TopicDomain.persistent.value())) {
+            assertEquals(tv1.size(), 1);
+            assertEquals(tv.get("key2"), "value2");
+        } else {
+            assertEquals(tv1.size(), 0);
+        }
     }
 
     @DataProvider(name = "partitionedTopic")


### PR DESCRIPTION
### Motivation

Currently, the table view only supports persistent topics with read compacted.

However, some data don't require persistent storage, like load data in PIP-192 [#16691](https://github.com/apache/pulsar/issues/16691). 

### Modifications

Make table view support non-persistent topic



### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
