### PR TITLE
[fix][broker] Fix ExtensibleLoadManager flaky test 

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -385,7 +385,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
 
     private CompletableFuture<String> getOwnerAsync(
             ServiceUnitId serviceUnit, String bundle, boolean ownByLocalBrokerIfAbsent) {
-        return serviceUnitStateChannel.getOwnerAsync(bundle).thenCompose(broker -> {
+        return serviceUnitStateChannel.getOwnerAsync(bundle).thenComposeAsync(broker -> {
             // If the bundle not assign yet, select and publish assign event to channel.
             if (broker.isEmpty()) {
                 CompletableFuture<Optional<String>> selectedBroker;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerImpl.java
@@ -477,7 +477,7 @@ public class ExtensibleLoadManagerImpl implements ExtensibleLoadManager {
                                                            Set<String> excludeBrokerSet) {
         BrokerRegistry brokerRegistry = getBrokerRegistry();
         return brokerRegistry.getAvailableBrokerLookupDataAsync()
-                .thenCompose(availableBrokers -> {
+                .thenComposeAsync(availableBrokers -> {
                     LoadManagerContext context = this.getContext();
 
                     Map<String, BrokerLookupData> availableBrokerCandidates = new HashMap<>(availableBrokers);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerWrapper.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/ExtensibleLoadManagerWrapper.java
@@ -118,7 +118,6 @@ public class ExtensibleLoadManagerWrapper implements LoadManager {
     @Override
     public void writeLoadReportOnZookeeper() throws Exception {
         // No-op, this operation is not useful, the load data reporter will automatically write.
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -320,7 +320,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
                             "topicCompactionStrategyClassName",
                             ServiceUnitStateCompactionStrategy.class.getName()))
                     .create();
-            tableview.listen((key, value) -> handle(key, value));
+            tableview.listen((key, value) -> {
+                pulsar.getOrderedExecutor().chooseThread(key).execute(() -> handle(key, value));
+            });
             if (debug) {
                 log.info("Successfully started the channel tableview.");
             }
@@ -696,9 +698,11 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     }
 
     private void handleOwnEvent(String serviceUnit, ServiceUnitStateData data) {
-        var getOwnerRequest = getOwnerRequests.remove(serviceUnit);
-        if (getOwnerRequest != null) {
-            getOwnerRequest.complete(data.dstBroker());
+        synchronized (this) {
+            var getOwnerRequest = getOwnerRequests.remove(serviceUnit);
+            if (getOwnerRequest != null) {
+                getOwnerRequest.complete(data.dstBroker());
+            }
         }
         stateChangeListeners.notify(serviceUnit, data, null);
         if (isTargetBroker(data.dstBroker())) {
@@ -804,7 +808,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return broker.equals(lookupServiceAddress);
     }
 
-    private CompletableFuture<String> deferGetOwnerRequest(String serviceUnit) {
+    private synchronized CompletableFuture<String> deferGetOwnerRequest(String serviceUnit) {
         return getOwnerRequests
                 .computeIfAbsent(serviceUnit, k -> {
                     CompletableFuture<String> future = new CompletableFuture<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -478,7 +478,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return isOwner(serviceUnit, lookupServiceAddress);
     }
 
-    public CompletableFuture<Optional<String>> getOwnerAsync(String serviceUnit) {
+    public synchronized CompletableFuture<Optional<String>> getOwnerAsync(String serviceUnit) {
         if (!validateChannelState(Started, true)) {
             return CompletableFuture.failedFuture(
                     new IllegalStateException("Invalid channel state:" + channelState.name()));
@@ -608,9 +608,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         }).thenApply(__ -> null);
     }
 
-    private void handle(String serviceUnit, ServiceUnitStateData data) {
+    private synchronized void handle(String serviceUnit, ServiceUnitStateData data) {
         long totalHandledRequests = getHandlerTotalCounter(data).incrementAndGet();
-        if (log.isDebugEnabled()) {
+        if (debug()) {
             log.info("{} received a handle request for serviceUnit:{}, data:{}. totalHandledRequests:{}",
                     lookupServiceAddress, serviceUnit, data, totalHandledRequests);
         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -698,11 +698,9 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
     }
 
     private void handleOwnEvent(String serviceUnit, ServiceUnitStateData data) {
-        synchronized (this) {
-            var getOwnerRequest = getOwnerRequests.remove(serviceUnit);
-            if (getOwnerRequest != null) {
-                getOwnerRequest.complete(data.dstBroker());
-            }
+        var getOwnerRequest = getOwnerRequests.remove(serviceUnit);
+        if (getOwnerRequest != null) {
+            getOwnerRequest.complete(data.dstBroker());
         }
         stateChangeListeners.notify(serviceUnit, data, null);
         if (isTargetBroker(data.dstBroker())) {
@@ -808,7 +806,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return broker.equals(lookupServiceAddress);
     }
 
-    private synchronized CompletableFuture<String> deferGetOwnerRequest(String serviceUnit) {
+    private CompletableFuture<String> deferGetOwnerRequest(String serviceUnit) {
         return getOwnerRequests
                 .computeIfAbsent(serviceUnit, k -> {
                     CompletableFuture<String> future = new CompletableFuture<>();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -478,7 +478,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         return isOwner(serviceUnit, lookupServiceAddress);
     }
 
-    public synchronized CompletableFuture<Optional<String>> getOwnerAsync(String serviceUnit) {
+    public CompletableFuture<Optional<String>> getOwnerAsync(String serviceUnit) {
         if (!validateChannelState(Started, true)) {
             return CompletableFuture.failedFuture(
                     new IllegalStateException("Invalid channel state:" + channelState.name()));
@@ -608,7 +608,7 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
         }).thenApply(__ -> null);
     }
 
-    private synchronized void handle(String serviceUnit, ServiceUnitStateData data) {
+    private void handle(String serviceUnit, ServiceUnitStateData data) {
         long totalHandledRequests = getHandlerTotalCounter(data).incrementAndGet();
         if (debug()) {
             log.info("{} received a handle request for serviceUnit:{}, data:{}. totalHandledRequests:{}",

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -334,7 +334,8 @@ public class LoadManagerShared {
         final String namespaceName = getNamespaceNameFromBundleName(assignedBundleName);
         try {
             final Map<String, Integer> brokerToAntiAffinityNamespaceCount = getAntiAffinityNamespaceOwnedBrokers(pulsar,
-                    namespaceName, brokerToNamespaceToBundleRange).get(30, TimeUnit.SECONDS);
+                    namespaceName, brokerToNamespaceToBundleRange)
+                    .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             filterAntiAffinityGroupOwnedBrokers(pulsar, candidates, brokerToDomainMap,
                     brokerToAntiAffinityNamespaceCount);
         } catch (Exception e) {
@@ -400,7 +401,7 @@ public class LoadManagerShared {
         try {
             final Map<String, Integer> brokerToAntiAffinityNamespaceCount = getAntiAffinityNamespaceOwnedBrokers(
                     pulsar, namespaceName, bundleOwnershipData)
-                    .get(30, TimeUnit.SECONDS);
+                    .get(pulsar.getConfiguration().getMetadataStoreOperationTimeoutSeconds(), TimeUnit.SECONDS);
             filterAntiAffinityGroupOwnedBrokers(pulsar, candidates, brokerToDomainMap,
                     brokerToAntiAffinityNamespaceCount);
         } catch (Exception e) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/impl/LoadManagerShared.java
@@ -338,7 +338,7 @@ public class LoadManagerShared {
             filterAntiAffinityGroupOwnedBrokers(pulsar, candidates, brokerToDomainMap,
                     brokerToAntiAffinityNamespaceCount);
         } catch (Exception e) {
-            LOG.error("Failed to filter anti-affinity group namespace {}", e.getMessage());
+            LOG.error("Failed to filter anti-affinity group namespace.", e);
         }
     }
 
@@ -404,7 +404,7 @@ public class LoadManagerShared {
             filterAntiAffinityGroupOwnedBrokers(pulsar, candidates, brokerToDomainMap,
                     brokerToAntiAffinityNamespaceCount);
         } catch (Exception e) {
-            LOG.error("Failed to filter anti-affinity group namespace {}", e.getMessage());
+            LOG.error("Failed to filter anti-affinity group namespace.", e);
         }
     }
 

--- a/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
+++ b/tests/integration/src/test/java/org/apache/pulsar/tests/integration/loadbalance/ExtensibleLoadManagerTest.java
@@ -94,6 +94,7 @@ public class ExtensibleLoadManagerTest extends TestRetrySupport {
         brokerEnvs.put("forceDeleteNamespaceAllowed", "true");
         brokerEnvs.put("loadBalancerDebugModeEnabled", "true");
         brokerEnvs.put("topicLevelPoliciesEnabled", "false");
+        brokerEnvs.put("metadataStoreOperationTimeoutSeconds", "30");
         brokerEnvs.put("PULSAR_MEM", "-Xmx512M");
         spec.brokerEnvs(brokerEnvs);
         pulsarCluster = PulsarCluster.forSpec(spec);


### PR DESCRIPTION
Run unit test only 

### 1. Fix the deadlock by use `thenComposeAsync `
```
"metadata-store-9-1" #26 prio=5 os_prio=0 cpu=227.69ms elapsed=109.96s tid=0x000056447f5a14c0 nid=0xec waiting on condition  [0x00007f9db07d0000]
   java.lang.Thread.State: TIMED_WAITING (parking)
at jdk.internal.misc.Unsafe.park(java.base@17.0.7/Native Method)
- parking to wait for  <0x00001000048e8830> (a java.util.concurrent.CompletableFuture$Signaller)
at java.util.concurrent.locks.LockSupport.parkNanos(java.base@17.0.7/LockSupport.java:252)
at java.util.concurrent.CompletableFuture$Signaller.block(java.base@17.0.7/CompletableFuture.java:1866)
at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@17.0.7/ForkJoinPool.java:3463)
at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.7/ForkJoinPool.java:3434)
at java.util.concurrent.CompletableFuture.timedGet(java.base@17.0.7/CompletableFuture.java:1939)
at java.util.concurrent.CompletableFuture.get(java.base@17.0.7/CompletableFuture.java:2095)
at org.apache.pulsar.broker.loadbalance.impl.LoadManagerShared.filterAntiAffinityGroupOwnedBrokers(LoadManagerShared.java:403)
at org.apache.pulsar.broker.loadbalance.extensions.policies.AntiAffinityGroupPolicyHelper.filter(AntiAffinityGroupPolicyHelper.java:46)
at org.apache.pulsar.broker.loadbalance.extensions.filter.AntiAffinityGroupPolicyFilter.filter(AntiAffinityGroupPolicyFilter.java:43)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.lambda$selectAsync$16(ExtensibleLoadManagerImpl.java:494)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl$$Lambda$933/0x000000080187dfb8.apply(Unknown Source)
at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@17.0.7/CompletableFuture.java:1187)
at java.util.concurrent.CompletableFuture.thenCompose(java.base@17.0.7/CompletableFuture.java:2309)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.selectAsync(ExtensibleLoadManagerImpl.java:480)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.selectAsync(ExtensibleLoadManagerImpl.java:473)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.lambda$getOwnerAsync$9(ExtensibleLoadManagerImpl.java:396)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl$$Lambda$834/0x0000000801738890.apply(Unknown Source)
at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@17.0.7/CompletableFuture.java:1187)
at java.util.concurrent.CompletableFuture.thenCompose(java.base@17.0.7/CompletableFuture.java:2309)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.getOwnerAsync(ExtensibleLoadManagerImpl.java:388)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.lambda$assign$7(ExtensibleLoadManagerImpl.java:380)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl$$Lambda$656/0x00000008016a3b20.apply(Unknown Source)
at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap$Section.put(ConcurrentOpenHashMap.java:409)
at org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap.computeIfAbsent(ConcurrentOpenHashMap.java:243)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.dedupeLookupRequest(ExtensibleLoadManagerImpl.java:461)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerImpl.assign(ExtensibleLoadManagerImpl.java:374)
at org.apache.pulsar.broker.loadbalance.extensions.ExtensibleLoadManagerWrapper.findBrokerServiceUrl(ExtensibleLoadManagerWrapper.java:66)
at org.apache.pulsar.broker.namespace.NamespaceService.lambda$getBrokerServiceUrlAsync$0(NamespaceService.java:198)
at org.apache.pulsar.broker.namespace.NamespaceService$$Lambda$741/0x00000008016fd8d8.apply(Unknown Source)
at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@17.0.7/CompletableFuture.java:1187)
at java.util.concurrent.CompletableFuture.thenCompose(java.base@17.0.7/CompletableFuture.java:2309)
at org.apache.pulsar.broker.namespace.NamespaceService.lambda$getBrokerServiceUrlAsync$1(NamespaceService.java:191)
at org.apache.pulsar.broker.namespace.NamespaceService$$Lambda$740/0x00000008016fd690.apply(Unknown Source)
at java.util.concurrent.CompletableFuture.uniComposeStage(java.base@17.0.7/CompletableFuture.java:1187)
at java.util.concurrent.CompletableFuture.thenCompose(java.base@17.0.7/CompletableFuture.java:2309)
at org.apache.pulsar.broker.namespace.NamespaceService.getBrokerServiceUrlAsync(NamespaceService.java:189)
at org.apache.pulsar.broker.lookup.TopicLookupBase.lambda$internalLookupTopicAsync$6(TopicLookupBase.java:85)
at org.apache.pulsar.broker.lookup.TopicLookupBase$$Lambda$927/0x000000080187d228.apply(Unknown Source)
at java.util.concurrent.CompletableFuture$UniCompose.tryFire(java.base@17.0.7/CompletableFuture.java:1150)
at java.util.concurrent.CompletableFuture.postComplete(java.base@17.0.7/CompletableFuture.java:510)
at java.util.concurrent.CompletableFuture.complete(java.base@17.0.7/CompletableFuture.java:2147)
at org.apache.pulsar.metadata.impl.ZKMetadataStore.lambda$existsFromStore$9(ZKMetadataStore.java:349)
at org.apache.pulsar.metadata.impl.ZKMetadataStore$$Lambda$279/0x000000080138a950.run(Unknown Source)
at java.util.concurrent.Executors$RunnableAdapter.call(java.base@17.0.7/Executors.java:539)
at java.util.concurrent.FutureTask.run(java.base@17.0.7/FutureTask.java:264)
at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(java.base@17.0.7/ScheduledThreadPoolExecutor.java:304)
at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.7/ThreadPoolExecutor.java:1136)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.7/ThreadPoolExecutor.java:635)
at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
at java.lang.Thread.run(java.base@17.0.7/Thread.java:833)
```
